### PR TITLE
Set image sizes to Meraki ones based on Wordpress plugin

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ RESET=$(tput sgr0)
 BOLD=$(tput bold)
 
 # Image sizes, feel free to change
-declare -a sizes=("1920x1080" "1200x628" "1024x512" "600x400" "300x200")
+declare -a sizes=("1500x750" "1200x600" "1000x500" "840x600" "420x600")
 
 # Count images in root directory
 numFiles=( *.{png,jpeg,jpg} )
@@ -27,7 +27,7 @@ echo -e "${BLUE}===========================================${RESET}"
 for image in `ls *.{png,jpeg,jpg} -R 2>/dev/null`; do
 
     # Copy original to dist and originals folder
-    cp $image "dist/${image%.*}-original.png"
+    cp $image "dist/${image%.*}-original.jpg"
     cp $image originals/$image
 
     # Increment Progress
@@ -35,19 +35,19 @@ for image in `ls *.{png,jpeg,jpg} -R 2>/dev/null`; do
     echo -e "\n${BLUE}$progress/${#numFiles[@]}${RESET}${BOLD}\t\t$image${RESET}"
 
     # Compress image
-    convert -strip -interlace Plane -gaussian-blur 0.02 -quality 93% $image $image
+    /usr/local/opt/mozjpeg/bin/cjpeg -quality 90 -outfile "compress.jpg" $image && mv "compress.jpg" $image
     echo -e "${GREEN}Compressed \t$image${RESET}"
 
     # Generate sizes
     for size in "${sizes[@]}"; do
-        if [[ ! -f "dist/${image%.*}-$size.png" ]]; then
-            
+        if [[ ! -f "dist/${image%.*}-$size.jpg" ]]; then
+
             # Scales image without change in aspect ratio
-            convert ${image} -resize "$size" "dist/${image%.*}-scaled-$size.png"
+            convert ${image} -resize "$size" "dist/${image%.*}-scaled-$size.jpg"
             echo -e "${GREEN}Scaled  \t$image to\t($size)${RESET}"
 
             # Crops image form center to exact size
-            convert ${image} -resize "$size^" -gravity center -crop $size+0+0 +repage "dist/${image%.*}-cropped-$size.png"
+            convert ${image} -resize "$size^" -gravity center -crop $size+0+0 +repage "dist/${image%.*}-$size.jpg"
             echo -e "${GREEN}Cropped \t$image to\t($size)${RESET}"
         fi
     done

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ RESET=$(tput sgr0)
 BOLD=$(tput bold)
 
 # Image sizes, feel free to change
-declare -a sizes=("1500x750" "1200x600" "1000x500" "840x600" "420x600")
+declare -a sizes=("1500x750" "1200x1200" "1000x500" "600x600" "420x620")
 
 # Count images in root directory
 numFiles=( *.{png,jpeg,jpg} )


### PR DESCRIPTION
As well as depending on imagemagick this requires you to `brew install mozjpeg` to efficiently compress.